### PR TITLE
Add a model attribute 'denorm_always_skip'.

### DIFF
--- a/denorm/db/base.py
+++ b/denorm/db/base.py
@@ -78,7 +78,7 @@ class Trigger:
             self.db_table = self.model._meta.db_table
             # FIXME, need to check get_parent_list and add triggers to those
             # The below will only check the fields on *this* model, not parents
-            skip = skip or ()
+            skip = skip or () + getattr(subject, 'denorm_always_skip', ())
             self.fields = [(k.attname, k.db_type(connection=cconnection)) for k,v in self.model._meta.get_fields_with_model() if not v and k.attname not in skip]
         else:
             raise NotImplementedError

--- a/denorm/dependencies.py
+++ b/denorm/dependencies.py
@@ -29,7 +29,7 @@ class DependOnRelated(DenormDependency):
         self.other_model = othermodel
         self.fk_name = foreign_key
         self.type = type
-        self.skip = skip
+        self.skip = skip or () + getattr(othermodel, 'denorm_always_skip', ())
 
     def setup(self, this_model):
         super(DependOnRelated,self).setup(this_model)

--- a/test_project/test_app/models.py
+++ b/test_project/test_app/models.py
@@ -148,3 +148,11 @@ class SkipCommentWithSkip(SkipComment):
     @depend_on_related(SkipPost)
     def post_text(self):
         return self.post.text
+
+class SkipCommentWithAttributeSkip(SkipComment):
+    @denormalized(models.TextField)
+    @depend_on_related(SkipPost)
+    def post_text(self):
+        return self.post.text
+
+    denorm_always_skip = ('updated_on',)

--- a/test_project/test_app/tests.py
+++ b/test_project/test_app/tests.py
@@ -41,6 +41,13 @@ class TestSkip(cases.DestructiveDatabaseTestCase):
         
         denorm.flush()
 
+    def test_meta_skip(self):
+        """Test a model with the attribute listed under denorm_always_skip."""
+        comment = models.SkipCommentWithAttributeSkip(post=self.post, text='Yup, and they have wings!')
+        comment.save()
+
+        denorm.flush()
+
         
 class TestDenormalisation(cases.DestructiveDatabaseTestCase):
     """


### PR DESCRIPTION
This attribute can be set as a tuple of attribute names which will be
skipped for all denormed fields on this model or on another model
related to this one.

The motivation is that in practice you're never going to want to depend
on certain fields (such as a modified timestamp) and for a system where
there may be half a dozen or so denormed fields it's not very DRY!
