### PR TITLE
Doc Fix: lacking First Steps for tutorial and no comments on column creation

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -2,6 +2,23 @@
 Tutorial
 ========
 
+First steps
+===========
+
+You must add denorm app to your INSTALLED_APPS within your settings.py::
+
+
+    INSTALLED_APPS = (
+        ...
+        'denorm',
+        ...
+    )
+
+
+You also need to run the initial migration for denorm app::
+
+    $ python manage.py migrate denorm
+
 Counting related objects
 ========================
 
@@ -66,6 +83,8 @@ Example::
 
 in this example ``SomeModel`` will have a ``CharField`` named ``some_computation``.
 
+**Note:** You must add the column in the DB yourself (either manually or through a south migration) since 
+denorm won't perform that operation for you.
 
 Adding dependency information
 -----------------------------


### PR DESCRIPTION
Adds the first steps, and two necessary steps are included:
- Adding denorm to INSTALLED_APPS.
- Running initial denorm migration.

Also, adding a note on the requirement of manually creating the denormalized 
column when using denormalized decorator, which was not so clear before.
 
