### PR TITLE
don't use attname in the ORM update kwargs, not recognised

### DIFF
--- a/denorm/denorms.py
+++ b/denorm/denorms.py
@@ -109,7 +109,7 @@ class Denorm(object):
                 setattr(instance, attname, new_value)
                 # an update before the save is needed to handle CountFields
                 # CountField does not update its value during pre_save
-                qs.filter(pk=instance.pk).update(**{attname: new_value})
+                qs.filter(pk=instance.pk).update(**{self.fieldname: new_value})
                 instance.save()
         flush()
 


### PR DESCRIPTION
I had a denormalised field like:

``` python
@denormalized(models.ForeignKey, to='Team', null=True, blank=True)
@depend_on_related('Team', foreign_key='member')
def team(self):
    i, team = self._team_and_member_index()
    return team.pk
```

When I tried to `./manage.py denorm_rebuild` (or do a `rebuildall()` in python console) I was getting the error:

```
FieldDoesNotExist: Member has no field named 'team_id'
```

I think it's wrong to try and use the `attname` in the update query... this fixes it for me and I'm pretty sure shouldn't break anything else.
