### PR TITLE
Add denorm_drop management command to documentation

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -37,6 +37,9 @@ Management commands
 **denorm_init**
     .. automodule:: denorm.management.commands.denorm_init
 
+**denorm_drop**
+    .. automodule:: denorm.management.commands.denorm_drop
+
 **denorm_rebuild**
     .. automodule:: denorm.management.commands.denorm_rebuild
 


### PR DESCRIPTION
If I understand correctly, the necessary workflow to update triggers is `./manage.py denorm_drop && ./mange.py denorm_init`. Certainly `denorm_init` crashes if it is run a second time. So I just added this important command to the auto docs.
