### PR TITLE
using qs.iterator() in management denorm_flush, less memory usage

### DIFF
--- a/denorm/denorms.py
+++ b/denorm/denorms.py
@@ -520,7 +520,7 @@ def flush():
 
         # Call save() on all dirty instances, causing the self_save_handler()
         # getting called by the pre_save signal.
-        for dirty_instance in qs:
+        for dirty_instance in qs.iterator():
             if dirty_instance.content_object:
                 dirty_instance.content_object.save()
             dirty_instance.delete()


### PR DESCRIPTION
Hi!

I get really big memory usage thanks to not using qs.iterator() in default denorm_flush command. Do I need to make test for that?

Thanks for creating this app!
