### PR TITLE
Fix call signatures to match django 1.6

### DIFF
--- a/denorm/denorms.py
+++ b/denorm/denorms.py
@@ -253,7 +253,11 @@ class TriggerWhereNode(WhereNode):
                 lhs = '%s.%s' % (qn(table_alias), qn(name))
         else:
             lhs = qn(name)
-        return connection.ops.field_cast_sql(db_type, internal_type) % lhs
+        try:
+            response = connection.ops.field_cast_sql(db_type, internal_type) % lhs
+        except TypeError:
+            response = connection.ops.field_cast_sql(db_type) % lhs
+        return response
 
 
 class TriggerFilterQuery(sql.Query):


### PR DESCRIPTION
This pull request changes the call signature of TriggerWhereNode.sql_for_columns to match the changed call signature of Django 1.6.

It does this by adding an optional keyword argument, so it shouldn't break backwards compatibility.
