### PR TITLE
Denormalized ForeignKeys fixed

### DIFF
--- a/denorm/fields.py
+++ b/denorm/fields.py
@@ -58,8 +58,10 @@ def denormalized(DBField, *args, **kwargs):
             Updates the value of the denormalized field before it gets saved.
             """
             value = self.denorm.func(model_instance)
-            setattr(model_instance, self.attname, value)
-            return value
+            if self.attname != self.name:
+                setattr(model_instance, self.attname, None)
+            setattr(model_instance, self.name, value)
+            return getattr(model_instance, self.attname)
 
         def south_field_triple(self):
             """


### PR DESCRIPTION
Foreign keys should return an ID, but the denormalization function returns an object,
which should be set to the `self.name` attribute, rather than to `self.attname`;
and _then_, later, return `self.attname` attribute (this will effectively return the FK's PK).

Setting `self.attname` to `None` first is an optimization so the database is not hit in case
`self.name` attribute already has a value that is being overwritten.
