### PR TITLE
Inverted update save objects only one time, not once for each denorm

### DIFF
--- a/test_denorm_project/test_app/tests.py
+++ b/test_denorm_project/test_app/tests.py
@@ -424,9 +424,7 @@ class TestDenormalisation(TestCase):
         # We have to update the Attachment.forum field first to trigger this bug. Simply doing rebuildall() will
         # trigger an a1.save() at an some earlier point during the update. By the time we get to updating the value of
         # forum field the value is already correct and no update is done bypassing the broken code.
-        for d in denorms.alldenorms:
-            if d.model == models.Attachment and d.fieldname == 'forum':
-                d.update(models.Attachment.objects.all())
+        denorm.denorms.rebuildall(model_name='Attachment', field_name='forum')
 
     def test_denorm_subclass(self):
         f1 = models.Forum.objects.create(title="forumone")


### PR DESCRIPTION
This optimization allows for more efficient updating of objects with multiple `@denormalized` fields; improving upon the fact that such models where saved multiple times (once for each `@denormalized` field) in the model. The pull request makes it so only one save() is needed for each object.
