### PR TITLE
Update instead of save on rebuild, to prevent pre_save from overwriting

### DIFF
--- a/denorm/denorms.py
+++ b/denorm/denorms.py
@@ -532,7 +532,7 @@ def rebuildall(verbose=False, model_name=None, field_name=None):
                     fields.update(_fields)
                     save = True
             if save:
-                instance.save()
+                model.objects.filter(pk=instance.pk).update(**fields)
 
     flush()
 

--- a/denorm/denorms.py
+++ b/denorm/denorms.py
@@ -239,7 +239,7 @@ class CacheKeyDenorm(BaseCacheKeyDenorm):
 
 
 class TriggerWhereNode(WhereNode):
-    def sql_for_columns(self, data, qn, connection):
+    def sql_for_columns(self, data, qn, connection, internal_type=None):
         """
         Returns the SQL fragment used for the left-hand side of a column
         constraint (for example, the "T1.foo" portion in the clause
@@ -253,7 +253,7 @@ class TriggerWhereNode(WhereNode):
                 lhs = '%s.%s' % (qn(table_alias), qn(name))
         else:
             lhs = qn(name)
-        return connection.ops.field_cast_sql(db_type) % lhs
+        return connection.ops.field_cast_sql(db_type, internal_type) % lhs
 
 
 class TriggerFilterQuery(sql.Query):

--- a/denorm/denorms.py
+++ b/denorm/denorms.py
@@ -253,7 +253,11 @@ class TriggerWhereNode(WhereNode):
                 lhs = '%s.%s' % (qn(table_alias), qn(name))
         else:
             lhs = qn(name)
-        return connection.ops.field_cast_sql(db_type, internal_type) % lhs
+        try:
+            response = connection.ops.field_cast_sql(db_type, internal_type) % lhs
+        except TypeError:
+            response = connection.ops.field_cast_sql(db_type) % lhs
+        return response
 
 
 class TriggerFilterQuery(sql.Query):


### PR DESCRIPTION
I ran into a bug where pre_save from CountField overwrote the instance value with the value from the database just before writing to the database when using rebuild_all.

This changes rebuild_all to use update instead of save.