### PR TITLE
test_self_backward_relation test fails

### DIFF
--- a/test_denorm_project/test_app/tests.py
+++ b/test_denorm_project/test_app/tests.py
@@ -274,7 +274,7 @@ class TestDenormalisation(TestCase):
         p4 = models.Post.objects.create(forum=f1, response_to=p2)
         denorm.flush()
 
-        self.assertEqual(models.Post.objects.get(id=p1.id).response_count, 3)
+        self.assertEqual(models.Post.objects.get(id=p1.id).response_count, 2)
         self.assertEqual(models.Post.objects.get(id=p2.id).response_count, 1)
         self.assertEqual(models.Post.objects.get(id=p3.id).response_count, 0)
         self.assertEqual(models.Post.objects.get(id=p4.id).response_count, 0)


### PR DESCRIPTION
There are only two responses to post p1 in forum f1 (p2 and p3), but the test expects response_count to be 3, and it fails.
