### PR TITLE
Update links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ django-denorm is a Django application to provide automatic management of denorma
 
 This app uses database-level triggers, so is *not* database independent, but support is provided for MySQL, PostgreSQL and sqlite.
 
-Documentation is available from http://initcrash.github.com/django-denorm/
+Documentation is available from http://django-denorm.github.io/django-denorm/
 
-Issues can be reported at http://github.com/initcrash/django-denorm/issues
+Issues can be reported at http://github.com/django-denorm/django-denorm/issues
 
 [![Build Status](https://travis-ci.org/django-denorm/django-denorm.svg?branch=develop)](https://travis-ci.org/django-denorm/django-denorm)


### PR DESCRIPTION
Now that project has moved to the django-denorm organization, some of the links were wrong. The issues link redirected, but the documentation link 404ed.