### PR TITLE
Truncate identifiers

### DIFF
--- a/denorm/db/postgresql/triggers.py
+++ b/denorm/db/postgresql/triggers.py
@@ -1,5 +1,6 @@
 from django.db import transaction
 from denorm.db import base
+from django.db.backends.utils import truncate_name
 
 
 class RandomBigInt(base.RandomBigInt):
@@ -63,7 +64,7 @@ class Trigger(base.Trigger):
     def sql(self):
         qn = self.connection.ops.quote_name
 
-        name = self.name()
+        name = truncate_name(self.name(), self.connection.ops.max_name_length() - 5)
         params = []
         action_list = []
         actions_added = set()


### PR DESCRIPTION
When having really long table names (because of really long model names) the resulting function names will get truncated. Django itself has the same issue with long table names and uses django.db.backends.utils.truncate_name to provide unique and consistent names that are short enough not to be truncated.

This PR applies django's builtin truncate_name to the generated trigger functions.
