### PR TITLE
optimize rebuild command

### DIFF
--- a/test_denorm_project/test_app/migrations/0003_auto_20160119_0522.py
+++ b/test_denorm_project/test_app/migrations/0003_auto_20160119_0522.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('test_app', '0002_auto_20151014_1049'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CallCounter',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('called_count', models.IntegerField(editable=False)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='CallCounterProxy',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('test_app.callcounter',),
+        ),
+    ]

--- a/test_denorm_project/test_app/models.py
+++ b/test_denorm_project/test_app/models.py
@@ -204,6 +204,19 @@ class SkipPost(models.Model):
     text = models.TextField()
 
 
+class CallCounter(models.Model):
+    @denormalized(models.IntegerField)
+    def called_count(self):
+        if not self.called_count:
+            return 1
+        return self.called_count + 1
+
+
+class CallCounterProxy(CallCounter):
+    class Meta:
+        proxy = True
+
+
 class SkipComment(models.Model):
     post = models.ForeignKey(SkipPost)
     text = models.TextField()

--- a/test_denorm_project/test_app/tests.py
+++ b/test_denorm_project/test_app/tests.py
@@ -425,6 +425,22 @@ class TestDenormalisation(TransactionTestCase):
         self.assertEqual(f1.post_count, 1)
         self.assertEqual(f1.authors.all()[0], m1)
 
+    def test_denorm_rebuild_called_once(self):
+        """
+        Test whether the denorm function is not called only once during rebuild.
+        The proxy model CallCounterProxy should not add extra callings to denorm function.
+        """
+        models.CallCounter.objects.create()
+        denorm.denorms.flush()
+        c = models.CallCounter.objects.get()
+        self.assertEqual(c.called_count, 2)  # TODO: we should be able to create object with hitting the denorm function just once
+        denorm.denorms.rebuildall(verbose=True)
+        c = models.CallCounter.objects.get()
+        self.assertEqual(c.called_count, 3)
+        denorm.denorms.rebuildall(verbose=True)
+        c = models.CallCounter.objects.get()
+        self.assertEqual(c.called_count, 4)
+
     def test_denorm_update(self):
         f1 = models.Forum.objects.create(title="forumone")
         m1 = models.Member.objects.create(name="memberone")


### PR DESCRIPTION
-the denorm function is called only once (was 4x by trigger and by rebuild itself) during rebuild
-skip denorms on proxy models
-change verbose output
-add tests for that