### PR TITLE
Expose the 'func' decorated on the uninstatiated model class

### DIFF
--- a/denorm/fields.py
+++ b/denorm/fields.py
@@ -52,6 +52,8 @@ def denormalized(DBField, *args, **kwargs):
             models.signals.pre_save.connect(denorms.many_to_many_pre_save, sender=cls)
             models.signals.post_save.connect(denorms.many_to_many_post_save, sender=cls)
             DBField.contribute_to_class(self, cls, name, *args, **kwargs)
+            # The 'func' is acessible at the model Class, but swapped over on instances
+            setattr(cls, name, self.func)
 
         def pre_save(self, model_instance, add):
             """


### PR DESCRIPTION
This exposes the decorated `func` on the model class, not changing the behaviours of serving the denormalized value on the instances.

```
# models.py
class MyModel(models.Model):
    @denorm.denormalized(models.BooleanField)
    def as_bool(self):
        return True
```

```
>>> MyModel.as_bool
<unbound method MyModel.as_bool>
>>> model_instance = MyModel.objects.get(pk=123)
>>> model_instance.as_bool
True
```