### PR TITLE
[FIX] CacheKeyField should be "set to a random value" on every .save()

### DIFF
--- a/denorm/fields.py
+++ b/denorm/fields.py
@@ -280,14 +280,7 @@ class CacheKeyField(models.BigIntegerField):
         super(CacheKeyField, self).contribute_to_class(cls, name, *args, **kwargs)
 
     def pre_save(self, model_instance, add):
-        if add:
-            value = self.denorm.func(model_instance)
-        else:
-            value = self.denorm.model.objects.filter(
-                pk=model_instance.pk,
-            ).values_list(
-                self.attname, flat=True,
-            )[0]
+        value = self.denorm.func(model_instance)
         setattr(model_instance, self.attname, value)
         return value
 


### PR DESCRIPTION
Existing docs are now honored:
```
    A `BigIntegerField` that gets set to a random value anytime
    the model is saved or a dependency is triggered.
    The field gets updated immediately and does not require _denorm.flush()_.
    It currently cannot detect a direct (bulk)update to the model
    it is declared in.
```
  