### PR TITLE
Bug fix for AggregateFields with multi-table inheritance

### DIFF
--- a/denorm/fields.py
+++ b/denorm/fields.py
@@ -168,11 +168,16 @@ class AggregateField(models.PositiveIntegerField):
             value = 0
         else:
             # if we're updating, get the most recent value from the DB
-            value = self.denorm.model.objects.filter(
-                pk=model_instance.pk,
-            ).values_list(
-                self.attname, flat=True,
-            )[0]
+            try:
+                value = self.denorm.model.objects.filter(
+                    pk=model_instance.pk,
+                ).values_list(
+                    self.attname, flat=True,
+                )[0]
+            except IndexError:
+                # Aggregate fields on models that inherit from another concrete model
+                # call pre_save with add=False even when first saved in Django 1.6+
+                value = 0
 
         setattr(model_instance, self.attname, value)
         return value

--- a/test_denorm_project/test_app/models.py
+++ b/test_denorm_project/test_app/models.py
@@ -275,6 +275,17 @@ class Competitor(models.Model):
     team = models.ForeignKey(Team)
 
 
+class BaseConcreteModel(models.Model):
+    pass
+
+
+class ExtendedConcreteModel(BaseConcreteModel):
+    item_count = CountField('relatedmodel_set')
+
+
+class RelatedModel(models.Model):
+    thing = models.ForeignKey(ExtendedConcreteModel)
+
 
 if connection.vendor != "sqlite":
     class FilterSumModel(models.Model):

--- a/test_denorm_project/test_app/tests.py
+++ b/test_denorm_project/test_app/tests.py
@@ -369,6 +369,11 @@ class TestDenormalisation(TransactionTestCase):
         self.assertEqual(models.Forum.objects.get(id=f1.id).post_count, 2)
         self.assertEqual(models.Forum.objects.get(id=f1.id).title, "new")
 
+    def test_countfield_saves_on_inherited_model(self):
+        e1 = models.ExtendedConcreteModel()
+        e1.save()
+        self.assertIsNotNone(e1)
+
     def test_foreignkey(self):
         f1 = models.Forum.objects.create(title="forumone")
         f2 = models.Forum.objects.create(title="forumtwo")


### PR DESCRIPTION
In Django 1.6+, models inheriting from concrete base models call their fields' `pre_save()` methods with `add=False` even on first creation, which results in an `IndexError` when an `AggregateField` tries to get the most recent value from the DB:  
```
Error
Traceback (most recent call last):
  File ".../django-denorm/test_denorm_project/test_app/tests.py", line 374, in test_countfield_saves_on_inherited_model
    e1.save()
  File ".../python2.7/site-packages/django/db/models/base.py", line 590, in save
    force_update=force_update, update_fields=update_fields)
  File ".../python2.7/site-packages/django/db/models/base.py", line 618, in save_base
    updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
  File ".../python2.7/site-packages/django/db/models/base.py", line 677, in _save_table
    for f in non_pks]
  File ".../django-denorm/denorm/fields.py", line 176, in pre_save
    )[0]
  File ".../python2.7/site-packages/django/db/models/query.py", line 177, in __getitem__
    return list(qs)[0]
IndexError: list index out of range
```
Added a try/except to catch the `IndexError` and a test.